### PR TITLE
Update select_json to fix Python 3 compatibility

### DIFF
--- a/django_pgjsonb/fields.py
+++ b/django_pgjsonb/fields.py
@@ -380,13 +380,13 @@ def select_json(query, *args, **kwargs):
         return query
 
     def get_sql_str(opr):
-        if isinstance(opr, basestring):
+        if isinstance(opr, six.string_types):
             opr_elements = opr.split("__")
             field = opr_elements.pop(0)
             select_elements = ['"%s"."%s"' % (query.model._meta.db_table,field)]+["'%s'" % name for name in opr_elements]
             return "_".join(opr_elements), " -> ".join(select_elements)
 
-    return query.extra(select=dict([get_sql_str(opr) for opr in args], **{k: get_sql_str(v)[1] for k, v in kwargs.iteritems()}))
+    return query.extra(select=dict([get_sql_str(opr) for opr in args], **{k: get_sql_str(v)[1] for k, v in six.iteritems(kwargs)}))
 
 models.QuerySet.select_json = select_json
 


### PR DESCRIPTION
There were two instances where six could have been used in select_json that stopped it from working in Python 3. Since we already use six in the file, the fix is simple.
